### PR TITLE
Exoplayer: Use okhttp version specified in gradle.properties

### DIFF
--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -40,6 +40,6 @@ dependencies {
     implementation('com.google.android.exoplayer:extension-okhttp:2.11.4') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
-    implementation 'com.squareup.okhttp3:okhttp:3.14.3'
+    implementation 'com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}'
 
 }


### PR DESCRIPTION
Because React Native uses okhttp, including exoplayer causes apps to use two different versions of okhttp.  This results in some unpredictable behavior.  Clients of `react-native-video` should be able to specify the same OKHTTP version to react-native and react-native video.

See where it's specified in react-native trunk: 
- https://github.com/facebook/react-native/blob/master/ReactAndroid/gradle.properties#L15
- https://github.com/facebook/react-native/blob/e1b6cd3f756aa034b11af6bf9960efb42bde8692/ReactAndroid/build.gradle#L452-L453

Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

#### Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

#### Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

#### Focus the PR on only one area
Testing multiple features takes longer than isolated changes and if there is a bug in one feature, prevents the other parts of your PR from getting merged until it gets fixed.
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

#### Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
