### PR TITLE
Fix ExoPlayer: avoid stretching of HLS when aspect ratio changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Changelog
 
 ### Next Version
+
+* Fix ExoPlayer: avoid stretching of HLS when aspect ratio changes [#1302](https://github.com/react-native-community/react-native-video/pull/1302)
 * Partial support for timed metadata on Android MediaPlayer [#707](https://github.com/react-native-community/react-native-video/pull/707)
 * Support video caching for iOS [#955](https://github.com/react-native-community/react-native-video/pull/955)
 * Video caching cleanups [#1172](https://github.com/react-native-community/react-native-video/pull/1172)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -205,9 +205,7 @@ public final class ExoPlayerView extends FrameLayout {
             layout.setAspectRatio(height == 0 ? 1 : (width * pixelWidthHeightRatio) / height);
 
             // React native workaround for measuring and layout on initial load.
-            if (isInitialRatio) {
-                post(measureAndLayout);
-            }
+            post(measureAndLayout);
         }
 
         @Override

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -201,10 +201,7 @@ public final class ExoPlayerView extends FrameLayout {
 
         @Override
         public void onVideoSizeChanged(int width, int height, int unappliedRotationDegrees, float pixelWidthHeightRatio) {
-            boolean isInitialRatio = layout.getAspectRatio() == 0;
             layout.setAspectRatio(height == 0 ? 1 : (width * pixelWidthHeightRatio) / height);
-
-            // React native workaround for measuring and layout on initial load.
             post(measureAndLayout);
         }
 


### PR DESCRIPTION
from @defualt in https://github.com/react-native-video/react-native-video/pull/1302